### PR TITLE
Fix README: use `matrix` insted of `array`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ using RDatasets
 iris = data("datasets", "iris")
 
 # SVM format expects observations in columns and features in rows
-X = array(iris[:, 1:4])'
+X = matrix(iris[:, 1:4])'
 p, n = size(X)
 
 # SVM format expects positive and negative examples to +1/-1


### PR DESCRIPTION
I fix sample code on README.md, which doesn't work on julia 0.2.0 with DataArrays 0.0.3.
I'm afraid that it might be DataArrays's bug, using `matrix` instead of `array` seems to be fine.

``` julia
array(iris[:, 1:4])'

#=>  array not defined
```
