### PR TITLE
Use `countnz` instead of `nnz`

### DIFF
--- a/src/SVM.jl
+++ b/src/SVM.jl
@@ -12,7 +12,7 @@ end
 
 function Base.show(io::IO, fit::SVMFit)
 	@printf io "Fitted linear SVM\n"
-	@printf io " * Non-zero weights: %d\n" nnz(fit.w)
+	@printf io " * Non-zero weights: %d\n" countnz(fit.w)
 	@printf io " * Iterations: %d\n" fit.pass
 	@printf io " * Converged: %s\n" string(fit.converged)
 end


### PR DESCRIPTION
In `Base.show` function, there is deprecated function `nnz`.
It is preffered to use `countnz` instead of `nnz`.
